### PR TITLE
fix(ci): avoid forcing revCount in shallow clones

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
-    - run: nix-build
+    - run: nix-build -A default
 
   flakes:
     env:


### PR DESCRIPTION
This fixes the currently failing `simple-build` CI.

`actions/checkout` creates a shallow clone for simple-build. Nix 2.35 makes `fetchGit.revCount` unavailable for shallow repositories, while bare `nix-build` forces every top-level flake-compat attribute during derivation discovery.

Select the default derivation explicitly so revCount remains lazy and the legacy build works without fetching the full Git history.